### PR TITLE
Add more tests, refactor tests

### DIFF
--- a/tests/login/login.test.ts
+++ b/tests/login/login.test.ts
@@ -3,27 +3,141 @@ import { existingUsers } from '../../test-setup/localstorage.setup'
 
 test.describe.configure({ mode: 'serial' })
 
+const existingUser = existingUsers[0]
+const BASE_URL = 'http://localhost:8080'
+const LOGIN_URL = `${BASE_URL}/login`
+
 test.describe('login form tests', () => {
-  test('logging in works with existing account', async ({ page }) => {
-    await page.goto('localhost:8080/login')
+  test.beforeEach(async ({ page }) => {
+    // Go to the login page
+    await page.goto(LOGIN_URL)
+  })
 
-    const existingUser = existingUsers[0]
+  test('should be able to log in using existing account', async ({ page }) => {
+    // E-mail input
+    await page.getByLabel('Email').pressSequentially(existingUser.email)
 
+    // Password input
     await page
-      .locator('#root form div:nth-child(1) > div > input')
-      .pressSequentially(existingUser.email)
-
-    await page
-      .locator('#root form div:nth-child(2) > div > input')
+      .getByLabel('Password', { exact: true })
       .pressSequentially(existingUser.password)
 
-    // Submit button
-    const button = page.locator('form .MuiButton-sizeMedium')
-    // Click on the button
-    button.click()
+    // Click submit button
+    await page.getByRole('button', { name: 'LOGIN' }).click()
 
-    // Wait for 1 second until page is fully loaded
-    await page.waitForTimeout(1000)
+    // Wait for page to load
+    await page.waitForURL(BASE_URL)
+
+    // Expect to see the 'Log out' button
     await expect(page.getByText('Log out')).toBeVisible()
+  })
+
+  test('should see an error message when entering an invalid password', async ({
+    page,
+  }) => {
+    // E-mail input
+    await page.getByLabel('Email').pressSequentially(existingUser.email)
+
+    // Password input, using invalid password
+    await page
+      .getByLabel('Password', { exact: true })
+      .pressSequentially('wrong_password')
+
+    // Click submit button
+    await page.getByRole('button', { name: 'LOGIN' }).click()
+
+    // Expect to see error message 'Invalid credentials'
+    await expect(page.getByText('Invalid credentials')).toBeVisible()
+  })
+
+  test('should not be able to click the submit button without entering an email', async ({
+    page,
+  }) => {
+    // E-mail input, clear input
+    await page.getByLabel('Email').clear()
+
+    // Password input
+    await page
+      .getByLabel('Password', { exact: true })
+      .pressSequentially(existingUser.password)
+
+    // Expect submit button to be disabled
+    await expect(page.getByRole('button', { name: 'LOGIN' })).toBeDisabled()
+  })
+
+  test('should not be able to click the submit button when entering an invalid email format', async ({
+    page,
+  }) => {
+    // E-mail input, using e-mail without @
+    await page.getByLabel('Email').pressSequentially('test1mail.com')
+
+    // Password input
+    await page
+      .getByLabel('Password', { exact: true })
+      .pressSequentially(existingUser.password)
+
+    // Expect submit button to be disabled
+    await expect(page.getByRole('button', { name: 'LOGIN' })).toBeDisabled()
+  })
+
+  test('should not be able to click the submit button without entering a password', async ({
+    page,
+  }) => {
+    // E-mail input
+    await page.getByLabel('Email').pressSequentially(existingUser.email)
+
+    // Password , clear input
+    await page.getByLabel('Password', { exact: true }).clear()
+
+    // Expect submit button to be disabled
+    await expect(page.getByRole('button', { name: 'LOGIN' })).toBeDisabled()
+  })
+
+  test('should not be able to click the submit button when entering a password with fewer than 9 characters', async ({
+    page,
+  }) => {
+    // E-mail input
+    await page.getByLabel('Email').pressSequentially(existingUser.email)
+
+    // Password input, using 8 character password
+    await page
+      .getByLabel('Password', { exact: true })
+      .pressSequentially('12345678')
+
+    // Expect submit button to be disabled
+    await expect(page.getByRole('button', { name: 'LOGIN' })).toBeDisabled()
+  })
+
+  test('should be able to toggle visibility of entered password', async ({
+    page,
+  }) => {
+    // Password input
+    await page
+      .getByLabel('Password', { exact: true })
+      .pressSequentially(existingUser.password)
+
+    // Expect password to be hidden
+    await expect(page.getByLabel('Password', { exact: true })).toHaveAttribute(
+      'type',
+      'password',
+    )
+
+    // Toggle eye icon
+    await page.getByLabel('toggle password visibility').click()
+
+    // Expect password to be visible
+    await expect(page.getByLabel('Password', { exact: true })).toHaveAttribute(
+      'type',
+      'text',
+    )
+
+    // Toggle back eye icon
+    await page.getByLabel('toggle password visibility').click()
+
+    // Expect password to be hidden
+    await expect(page.getByLabel('Password', { exact: true })).toHaveAttribute(
+      'type',
+      'password',
+    )
   })
 })

--- a/tests/login/login.test.ts
+++ b/tests/login/login.test.ts
@@ -15,12 +15,12 @@ test.describe('login form tests', () => {
 
   test('should be able to log in using existing account', async ({ page }) => {
     // E-mail input
-    await page.getByLabel('Email').pressSequentially(existingUser.email)
+    await page.getByLabel('Email').fill(existingUser.email)
 
     // Password input
     await page
       .getByLabel('Password', { exact: true })
-      .pressSequentially(existingUser.password)
+      .fill(existingUser.password)
 
     // Click submit button
     await page.getByRole('button', { name: 'LOGIN' }).click()
@@ -36,12 +36,10 @@ test.describe('login form tests', () => {
     page,
   }) => {
     // E-mail input
-    await page.getByLabel('Email').pressSequentially(existingUser.email)
+    await page.getByLabel('Email').fill(existingUser.email)
 
     // Password input, using invalid password
-    await page
-      .getByLabel('Password', { exact: true })
-      .pressSequentially('wrong_password')
+    await page.getByLabel('Password', { exact: true }).fill('wrong_password')
 
     // Click submit button
     await page.getByRole('button', { name: 'LOGIN' }).click()
@@ -59,7 +57,7 @@ test.describe('login form tests', () => {
     // Password input
     await page
       .getByLabel('Password', { exact: true })
-      .pressSequentially(existingUser.password)
+      .fill(existingUser.password)
 
     // Expect submit button to be disabled
     await expect(page.getByRole('button', { name: 'LOGIN' })).toBeDisabled()
@@ -69,12 +67,12 @@ test.describe('login form tests', () => {
     page,
   }) => {
     // E-mail input, using e-mail without @
-    await page.getByLabel('Email').pressSequentially('test1mail.com')
+    await page.getByLabel('Email').fill('test1mail.com')
 
     // Password input
     await page
       .getByLabel('Password', { exact: true })
-      .pressSequentially(existingUser.password)
+      .fill(existingUser.password)
 
     // Expect submit button to be disabled
     await expect(page.getByRole('button', { name: 'LOGIN' })).toBeDisabled()
@@ -84,7 +82,7 @@ test.describe('login form tests', () => {
     page,
   }) => {
     // E-mail input
-    await page.getByLabel('Email').pressSequentially(existingUser.email)
+    await page.getByLabel('Email').fill(existingUser.email)
 
     // Password , clear input
     await page.getByLabel('Password', { exact: true }).clear()
@@ -97,12 +95,10 @@ test.describe('login form tests', () => {
     page,
   }) => {
     // E-mail input
-    await page.getByLabel('Email').pressSequentially(existingUser.email)
+    await page.getByLabel('Email').fill(existingUser.email)
 
     // Password input, using 8 character password
-    await page
-      .getByLabel('Password', { exact: true })
-      .pressSequentially('12345678')
+    await page.getByLabel('Password', { exact: true }).fill('12345678')
 
     // Expect submit button to be disabled
     await expect(page.getByRole('button', { name: 'LOGIN' })).toBeDisabled()
@@ -114,7 +110,7 @@ test.describe('login form tests', () => {
     // Password input
     await page
       .getByLabel('Password', { exact: true })
-      .pressSequentially(existingUser.password)
+      .fill(existingUser.password)
 
     // Expect password to be hidden
     await expect(page.getByLabel('Password', { exact: true })).toHaveAttribute(


### PR DESCRIPTION
# Login Form Tests
The login form test suite did successfully test the arguably most important test, logging in. This PR suggests some refactoring and additional tests to improve the test suite, in the established style.

## Refactoring
- Descriptive test names that communicate the intent, for added readability.
- A beforeEach hook for the login page to reduce code duplication.
- Variables for URLs, to make the tests easy to maintain.
- Removal of the button variable to shorten the tests.
- Using accessibility-focused selectors, for accessibility and to make the tests easier to maintain in case of UI changes.
- Using navigation assertions with waitForURL instead of arbitrary timeout.
- Using fill to enter text.

## Test Coverage
- Expanding with 6 additional test cases that verify:
  - Error handling for invalid credentials.
  - Form validation for empty email or password input.
  - Form validation for email format requiring @, based on /LoginPage/Form.tsx.
  - Form validation for password character length requirements, based on /LoginPage/Form.tsx.
  - Password visibility toggle functionality.
 
## Comments
This might be outside the scope of this PR, but additional improvements could be testing of accessibility and different screen sizes.