### PR TITLE
Add test suite for form functionality, and for validations.

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   projects: [
     // Setup project
     { name: 'setup', testDir: './test-setup/', testMatch: '*' },
+    // Chromium project
     {
       name: 'chromium',
       testDir: './tests/',
@@ -15,6 +16,18 @@ export default defineConfig({
         // Use "database" with existing accounts
         storageState: setupFile,
       },
+      dependencies: ['setup'],
+    },
+    // Mobile Chrome project
+    {
+      name: 'mobile chrome',
+      use: { ...devices['Pixel 7'] },
+      dependencies: ['setup'],
+    },
+    // Tablet project
+    {
+      name: 'tablet',
+      use: { ...devices['iPad (gen 7)'] },
       dependencies: ['setup'],
     },
   ],

--- a/tests/signup/signup-form.test.ts
+++ b/tests/signup/signup-form.test.ts
@@ -49,6 +49,12 @@ test.describe('signup form works and logging in is possible', () => {
     // Wait for login page to load
     await page.waitForURL(LOGIN_URL)
 
+    // Try to go to homepage while logged out
+    await page.goto(BASE_URL)
+
+    // Wait for login page to load after being redirected from homepage
+    await page.waitForURL(LOGIN_URL)
+
     // Fill in login fields
     await page.getByRole('textbox', { name: 'Email' }).fill(newUser.email)
     await page.getByRole('textbox', { name: 'Password' }).fill(newUser.password)

--- a/tests/signup/signup-form.test.ts
+++ b/tests/signup/signup-form.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+const BASE_URL = 'http://localhost:8080'
+const SIGNUP_URL = `${BASE_URL}/signup`
+const LOGIN_URL = `${BASE_URL}/login`
+
+// Test case new user, email contains @ character and password contains more than 8 characters
+const newUser = {
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'new_account@mail.com',
+  password: 'new_password',
+}
+
+test.describe('signup form works and logging in is possible', () => {
+  // Test the complete authentication flow: signup, logout, and login
+  test('should be able to sign up using form, log out and then log in', async ({
+    page,
+  }) => {
+    // Go to the signup page
+    await page.goto(SIGNUP_URL)
+
+    // Fill in fields
+    await page
+      .getByRole('textbox', { name: 'First name' })
+      .fill(newUser.firstName)
+    await page
+      .getByRole('textbox', { name: 'Last name' })
+      .fill(newUser.lastName)
+    await page.getByRole('textbox', { name: 'Email' }).fill(newUser.email)
+    await page.getByRole('textbox', { name: 'Password' }).fill(newUser.password)
+
+    // Click submit button
+    await page.getByRole('button', { name: 'SUBMIT' }).click()
+
+    // Wait for home page to load
+    await page.waitForURL(BASE_URL)
+
+    // Expect to see new user first and last name
+    await expect(
+      page.getByText(newUser.firstName + ' ' + newUser.lastName),
+    ).toBeVisible()
+
+    // Click log out button
+    await page.getByRole('button', { name: 'Log out' }).click()
+
+    // Wait for login page to load
+    await page.waitForURL(LOGIN_URL)
+
+    // Fill in login fields
+    await page.getByRole('textbox', { name: 'Email' }).fill(newUser.email)
+    await page.getByRole('textbox', { name: 'Password' }).fill(newUser.password)
+
+    // Click login button
+    await page.getByRole('button', { name: 'LOGIN' }).click()
+
+    // Wait for homepage to load
+    await page.waitForURL(BASE_URL)
+
+    // Expect to see new user first and last name
+    await expect(
+      page.getByText(newUser.firstName + ' ' + newUser.lastName),
+    ).toBeVisible()
+  })
+})

--- a/tests/signup/signup-validation.test.ts
+++ b/tests/signup/signup-validation.test.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test'
+import { existingUsers } from '../../test-setup/localstorage.setup'
+
+interface SignupFormFields {
+  firstName?: string
+  lastName?: string
+  email?: string
+  password?: string
+}
+
+test.describe.configure({ mode: 'serial' })
+
+const existingUser = existingUsers[0]
+const BASE_URL = 'http://localhost:8080'
+const SIGNUP_URL = `${BASE_URL}/signup`
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(SIGNUP_URL)
+})
+
+// Helper function for filling in fields
+const fillSignupForm = async (page, fields: Partial<SignupFormFields>) => {
+  if (fields.firstName !== undefined) {
+    await page
+      .getByRole('textbox', { name: 'First name' })
+      .fill(fields.firstName)
+  }
+  if (fields.lastName !== undefined) {
+    await page.getByRole('textbox', { name: 'Last name' }).fill(fields.lastName)
+  }
+  if (fields.email !== undefined) {
+    await page.getByRole('textbox', { name: 'Email' }).fill(fields.email)
+  }
+  if (fields.password !== undefined) {
+    await page.getByRole('textbox', { name: 'Password' }).fill(fields.password)
+  }
+}
+
+// Helper function for checking enabled/disabled status of the submit button
+const expectSubmitButtonToBe = async (page, state: 'disabled' | 'enabled') => {
+  if (state === 'disabled') {
+    await expect(page.getByRole('button', { name: 'SUBMIT' })).toBeDisabled()
+  } else if (state === 'enabled') {
+    await expect(page.getByRole('button', { name: 'SUBMIT' })).toBeEnabled()
+  }
+}
+
+test.describe('signup form validations', () => {
+  // 1. Test email validation
+  test('should not be able to click the submit button when entering an invalid email', async ({
+    page,
+  }) => {
+    // Fill in fields using invalid email without @ character
+    await fillSignupForm(page, {
+      firstName: existingUser.firstName,
+      lastName: existingUser.lastName,
+      email: 'invalidemail.com',
+      password: existingUser.password,
+    })
+
+    // Login button should be disabled
+    await expectSubmitButtonToBe(page, 'disabled')
+
+    // Fill in email with valid email
+    await fillSignupForm(page, { email: existingUser.email })
+
+    // Login button should be enabled
+    await expectSubmitButtonToBe(page, 'enabled')
+  })
+
+  // 2. Test password validation
+  test('should not be able to click the submit button when entering a password with fewer than 9 characters', async ({
+    page,
+  }) => {
+    // Fill in fields using invalid password with less than 9 characters
+    await fillSignupForm(page, {
+      firstName: existingUser.firstName,
+      lastName: existingUser.lastName,
+      email: existingUser.email,
+      password: '12345678',
+    })
+
+    // Login button should be disabled
+    await expectSubmitButtonToBe(page, 'disabled')
+
+    // Fill in valid password
+    await fillSignupForm(page, { password: existingUser.password })
+
+    // Login button should be enabled
+    await expectSubmitButtonToBe(page, 'enabled')
+  })
+
+  // 3. Test required fields validation
+  test('should not be able to click the submit button while any input is left empty', async ({
+    page,
+  }) => {
+    // Fill in fields
+    await fillSignupForm(page, {
+      firstName: existingUser.firstName,
+      lastName: existingUser.lastName,
+      email: existingUser.email,
+      password: existingUser.password,
+    })
+
+    // Login button should be enabled
+    await expectSubmitButtonToBe(page, 'enabled')
+
+    // Clear first name field
+    await fillSignupForm(page, {
+      firstName: '',
+    })
+
+    // Login button should be disabled
+    await expectSubmitButtonToBe(page, 'disabled')
+
+    // Fill in first name and clear last name
+    await fillSignupForm(page, {
+      firstName: existingUser.firstName,
+      lastName: '',
+    })
+
+    // Login button should be disabled
+    await expectSubmitButtonToBe(page, 'disabled')
+
+    // Fill in last name and clear email
+    await fillSignupForm(page, {
+      lastName: existingUser.lastName,
+      email: '',
+    })
+
+    // Login button should be disabled
+    await expectSubmitButtonToBe(page, 'disabled')
+
+    // Fill in email name and clear password
+    await fillSignupForm(page, {
+      email: existingUser.email,
+      password: '',
+    })
+
+    // Login button should be disabled
+    await expectSubmitButtonToBe(page, 'disabled')
+  })
+
+  // 4. Test toggling of password visibility
+  test('should be able to toggle visibility of entered password', async ({
+    page,
+  }) => {
+    // Password input
+    await fillSignupForm(page, {
+      password: existingUser.password,
+    })
+
+    // Expect password to be hidden
+    await expect(
+      page.getByRole('textbox', { name: 'Password' }),
+    ).toHaveAttribute('type', 'password')
+
+    // Toggle eye icon
+    await page.getByLabel('toggle password visibility').click()
+
+    // Expect password to be visible
+    await expect(
+      page.getByRole('textbox', { name: 'Password' }),
+    ).toHaveAttribute('type', 'text')
+
+    // Toggle back eye icon
+    await page.getByLabel('toggle password visibility').click()
+
+    // Expect password to be hidden
+    await expect(
+      page.getByRole('textbox', { name: 'Password' }),
+    ).toHaveAttribute('type', 'password')
+  })
+})


### PR DESCRIPTION
# Signup Form Tests

This PR adds two test suites in `/tests/signup`, each in their own file for greater clarity. One tests the complete user journey of signing up and then logging in with the new account, and the other focuses on form validation rules. More devices are also added to the Playwright config for testing across different screen sizes.

## Signup Form Function
- Authentication Flow Test: User journey with signup, logout and login.
- Verification of successful account creation.
- Confirmation that user is successfully logged out.
- Proper UI element verification at each stage of the flow.

## Validation Tests
- Email format validation (must include @)
- Password length verification (minimum 9 characters)
- Required fields validation
- Password visibility toggling

## Technical Decisions
1. **Helper Functions**: Created reusable functions for form filling and button state verification to reduce code duplication and improve readability for the validation test suite.

2. **Selector Strategy**: Used ARIA-based selectors `getByRole` for better accessibility testing.

3.  **Playwright Config update**: Added a phone and tablet for testing across different devices.

## Comments
**Important**: There is currently no mechanism that stops a user from signing up with an email that is already in use, and effectively changing the names and password for that account. A test case should be added for this validation once it is in place.

**Suggestion**: Maybe we should implement a separate accessibility testing utility to be imported into all of our tests? We have access to great tools in the `@axe-core/playwright` package.